### PR TITLE
Small Projected Camera Fix

### DIFF
--- a/src/UsgsAstroProjectedSensorModel.cpp
+++ b/src/UsgsAstroProjectedSensorModel.cpp
@@ -197,7 +197,9 @@ UsgsAstroProjectedSensorModel::UsgsAstroProjectedSensorModel() {}
 //*****************************************************************************
 // UsgsAstroProjectedSensorModel Destructor
 //*****************************************************************************
-UsgsAstroProjectedSensorModel::~UsgsAstroProjectedSensorModel() {}
+UsgsAstroProjectedSensorModel::~UsgsAstroProjectedSensorModel() {
+  delete m_camera;
+}
 
 //---------------------------------------------------------------------------
 // Core Photogrammetry
@@ -287,6 +289,12 @@ csm::EcefCoord UsgsAstroProjectedSensorModel::imageToGround(
   std::vector<double> meterCoord = pixelToMeter(image_pt.line, image_pt.samp, m_geoTransform);
   meterLine = meterCoord[0];
   meterSamp = meterCoord[1];
+  MESSAGE_LOG(
+      spdlog::level::trace,
+      "METERS X: {0:.15f}", meterLine);
+  MESSAGE_LOG(
+      spdlog::level::trace,
+      "METERS Y: {0:.15f}", meterSamp);
   PJ_CONTEXT *C = proj_context_create();
 
   /* Create a projection. */

--- a/src/Utilities.cpp
+++ b/src/Utilities.cpp
@@ -1532,16 +1532,10 @@ std::vector<double> pixelToMeter(double line, double sample, std::vector<double>
   double meter_x = (sample * geoTransform[1]) + geoTransform[0];
   double meter_y = (line * geoTransform[5]) + geoTransform[3];
 
-  meter_x += geoTransform[1] * 0.5;
-  meter_y += geoTransform[5] * 0.5;
-
   return {meter_y, meter_x};
 }
 
 std::vector<double> meterToPixel(double meter_x, double meter_y, std::vector<double> geoTransform) {
-  meter_x -= geoTransform[1] * 0.5;
-  meter_y -= geoTransform[5] * 0.5;
-
   double sample = (meter_x - geoTransform[0]) / geoTransform[1];
   double line = (meter_y - geoTransform[3]) / geoTransform[5];
 

--- a/tests/PluginTests.cpp
+++ b/tests/PluginTests.cpp
@@ -26,7 +26,7 @@ TEST(PluginTests, ReleaseDate) {
 
 TEST(PluginTests, NumModels) {
   UsgsAstroPlugin testPlugin;
-  EXPECT_EQ(4, testPlugin.getNumModels());
+  EXPECT_EQ(5, testPlugin.getNumModels());
 }
 
 TEST(PluginTests, BadISDFile) {

--- a/tests/UtilitiesTests.cpp
+++ b/tests/UtilitiesTests.cpp
@@ -639,7 +639,7 @@ TEST(UtilitiesTests, sanitizeTest) {
 
 TEST(UtilitiesTests, pixelToMeterTest) {
   std::vector<double> geoTransform = {-104607.78948592, 4.980137561815, 0.0, -570564.40018202, 0.0, -4.980137561815};
-  std::vector<double> ret = pixelToMeter(13.1191, 4981.08, geoTransform);
+  std::vector<double> ret = pixelToMeter(13.6191, 4981.58, geoTransform);
   EXPECT_NEAR(ret[0], -570632.225173488, 1e-4);
   EXPECT_NEAR(ret[1], -79798.83581073358, 1e-4);
 }
@@ -647,6 +647,6 @@ TEST(UtilitiesTests, pixelToMeterTest) {
 TEST(UtilitiesTests, meterToPixelTest) {
   std::vector<double> geoTransform = {-104607.78948592, 4.980137561815, 0.0, -570564.40018202, 0.0, -4.980137561815};
   std::vector<double> ret = meterToPixel(-79798.83581073358, -570632.225173488, geoTransform);
-  EXPECT_NEAR(ret[0], 13.1191, 1e-4);
-  EXPECT_NEAR(ret[1], 4981.0800000000099, 1e-4);
+  EXPECT_NEAR(ret[0], 13.6191, 1e-4);
+  EXPECT_NEAR(ret[1], 4981.5800000000099, 1e-4);
 }


### PR DESCRIPTION
A known .5 pixel offset exists between ISIS and CSM. This was being handled inside of the projected camera model, and should now be handled externally by the user if they are comparing ISIS and CSM