### PR TITLE
FrameSensor: Make many members public so they can be changed

### DIFF
--- a/include/usgscsm/UsgsAstroFrameSensorModel.h
+++ b/include/usgscsm/UsgsAstroFrameSensorModel.h
@@ -347,7 +347,6 @@ class UsgsAstroFrameSensorModel : public csm::RasterGM,
 
   static const std::string _SENSOR_MODEL_NAME;
 
- private:
   // Input parameters
   static const int m_numParameters;
   static const std::string m_parameterName[];
@@ -397,6 +396,8 @@ class UsgsAstroFrameSensorModel : public csm::RasterGM,
   int m_nParameters;
 
   csm::EcefCoord m_referencePointXyz;
+
+ private:
 
   std::shared_ptr<spdlog::logger> m_logger = spdlog::get("usgscsm_logger");
 


### PR DESCRIPTION
The FrameSensor class has its members private, but has no set or get functions so those cannot be accessed. This is a proposal to make them public, as done already for the Linescan class. (A few members will still be kept private, which are internal states, such as the logger and the _state variable). 

I care primarily for the intrinsics (distortion, focal length), camera position, and camera orientation, as those are needed in bundle adjustment. But I don't think there's harm in having other class parameters be public, such as semi-major axis, semi-minor axis, etc. 

Thoughts? 