### PR TITLE
No need for tolerance check for radial distortion

### DIFF
--- a/src/Distortion.cpp
+++ b/src/Distortion.cpp
@@ -94,11 +94,11 @@ void removeDistortion(double dx, double dy, double &ux, double &uy,
     case RADIAL: {
       double rr = dx * dx + dy * dy;
 
-        double dr = opticalDistCoeffs[0] +
-                    (rr * (opticalDistCoeffs[1] + rr * opticalDistCoeffs[2]));
+      double dr = opticalDistCoeffs[0] +
+                  (rr * (opticalDistCoeffs[1] + rr * opticalDistCoeffs[2]));
 
-        ux = dx * (1.0 - dr);
-        uy = dy * (1.0 - dr);
+      ux = dx * (1.0 - dr);
+      uy = dy * (1.0 - dr);
     } break;
 
     // Computes undistorted focal plane (x,y) coordinates given a distorted
@@ -332,43 +332,43 @@ void applyDistortion(double ux, double uy, double &dx, double &dy,
     case RADIAL: {
       double rp2 = (ux * ux) + (uy * uy);
 
-        double rp = sqrt(rp2);
-        // Compute first fractional distortion using rp
-        double drOverR =
-            opticalDistCoeffs[0] +
-            (rp2 * (opticalDistCoeffs[1] + (rp2 * opticalDistCoeffs[2])));
+      double rp = sqrt(rp2);
+      // Compute first fractional distortion using rp
+      double drOverR =
+          opticalDistCoeffs[0] +
+          (rp2 * (opticalDistCoeffs[1] + (rp2 * opticalDistCoeffs[2])));
 
-        // Compute first distorted point estimate, r
-        double r = rp + (drOverR * rp);
-        double r_prev, r2_prev;
-        int iteration = 0;
+      // Compute first distorted point estimate, r
+      double r = rp + (drOverR * rp);
+      double r_prev, r2_prev;
+      int iteration = 0;
 
-        do {
-          // Don't get in an end-less loop.  This algorithm should
-          // converge quickly.  If not then we are probably way outside
-          // of the focal plane.  Just set the distorted position to the
-          // undistorted position. Also, make sure the focal plane is less
-          // than 1km, it is unreasonable for it to grow larger than that.
-          if (iteration >= 20 || r > 1E9) {
-            drOverR = 0.0;
-            break;
-          }
+      do {
+        // Don't get in an end-less loop.  This algorithm should
+        // converge quickly.  If not then we are probably way outside
+        // of the focal plane.  Just set the distorted position to the
+        // undistorted position. Also, make sure the focal plane is less
+        // than 1km, it is unreasonable for it to grow larger than that.
+        if (iteration >= 20 || r > 1E9) {
+          drOverR = 0.0;
+          break;
+        }
 
-          r_prev = r;
-          r2_prev = r * r;
+        r_prev = r;
+        r2_prev = r * r;
 
-          // Compute new fractional distortion:
-          drOverR = opticalDistCoeffs[0] +
-                    (r2_prev *
-                     (opticalDistCoeffs[1] + (r2_prev * opticalDistCoeffs[2])));
+        // Compute new fractional distortion:
+        drOverR = opticalDistCoeffs[0] +
+                  (r2_prev *
+                   (opticalDistCoeffs[1] + (r2_prev * opticalDistCoeffs[2])));
 
-          // Compute new estimate of r
-          r = rp + (drOverR * r_prev);
-          iteration++;
-        } while (fabs(r - r_prev) > desiredPrecision);
+        // Compute new estimate of r
+        r = rp + (drOverR * r_prev);
+        iteration++;
+      } while (fabs(r - r_prev) > desiredPrecision);
 
-        dx = ux / (1.0 - drOverR);
-        dy = uy / (1.0 - drOverR);
+      dx = ux / (1.0 - drOverR);
+      dy = uy / (1.0 - drOverR);
       
     } break;
     case TRANSVERSE: {

--- a/src/Distortion.cpp
+++ b/src/Distortion.cpp
@@ -94,13 +94,11 @@ void removeDistortion(double dx, double dy, double &ux, double &uy,
     case RADIAL: {
       double rr = dx * dx + dy * dy;
 
-      if (rr > tolerance) {
         double dr = opticalDistCoeffs[0] +
                     (rr * (opticalDistCoeffs[1] + rr * opticalDistCoeffs[2]));
 
         ux = dx * (1.0 - dr);
         uy = dy * (1.0 - dr);
-      }
     } break;
 
     // Computes undistorted focal plane (x,y) coordinates given a distorted
@@ -221,7 +219,7 @@ void removeDistortion(double dx, double dy, double &ux, double &uy,
       bool done;
 
       /****************************************************************************
-       * Pre-loop intializations
+       * Pre-loop initializations
        ****************************************************************************/
 
       r2 = dy * dy + dx * dx;
@@ -255,7 +253,7 @@ void removeDistortion(double dx, double dy, double &ux, double &uy,
       } while (!done);
 
       /****************************************************************************
-       * Sucess ...
+       * Success ...
        ****************************************************************************/
 
       ux = guess_ux;
@@ -327,14 +325,13 @@ void applyDistortion(double ux, double uy, double &dx, double &dy,
   dy = uy;
 
   switch (distortionType) {
-    // Compute undistorted focal plane coordinate given a distorted
-    // focal plane coordinate. This case works by iteratively adding distortion
+    // Compute distorted focal plane coordinate given undistorted
+    // focal plane coordinates. This case works by iteratively adding distortion
     // until the new distorted point, r, undistorts to within a tolerance of the
     // original point, rp.
     case RADIAL: {
       double rp2 = (ux * ux) + (uy * uy);
 
-      if (rp2 > tolerance) {
         double rp = sqrt(rp2);
         // Compute first fractional distortion using rp
         double drOverR =
@@ -372,7 +369,7 @@ void applyDistortion(double ux, double uy, double &dx, double &dy,
 
         dx = ux / (1.0 - drOverR);
         dy = uy / (1.0 - drOverR);
-      }
+      
     } break;
     case TRANSVERSE: {
       computeTransverseDistortion(ux, uy, dx, dy, opticalDistCoeffs);
@@ -468,7 +465,7 @@ void applyDistortion(double ux, double uy, double &dx, double &dy,
 
     // The LRO LROC NAC distortion model uses an iterative approach to go from
     // undistorted x,y to distorted x,y
-    // Algorithum adapted from ISIS3 LRONarrowAngleDistortionMap.cpp
+    // Algorithm adapted from ISIS3 LRONarrowAngleDistortionMap.cpp
     case LROLROCNAC: {
       double yt = uy;
 
@@ -491,9 +488,9 @@ void applyDistortion(double ux, double uy, double &dx, double &dy,
 
       double dk1 = opticalDistCoeffs[0];
 
-      // Owing to the odd distotion model employed in this senser if |y| is >
+      // Owing to the odd distortion model employed in this sensor if |y| is >
       // 116.881145553046 then there is no root to find.  Further, the greatest
-      // y that any measure on the sensor will acutally distort to is less
+      // y that any measure on the sensor will actually distort to is less
       // than 20.  Thus, if any distorted measure is greater that that skip the
       // iterations.  The points isn't in the cube, and exactly how far outside
       // the cube is irrelevant.  Just let the camera model know its not in the

--- a/tests/DistortionTests.cpp
+++ b/tests/DistortionTests.cpp
@@ -124,17 +124,26 @@ TEST(transverse, removeDistortion_AlternatingOnes) {
   EXPECT_NEAR(uy, 7.5, 1e-8);
 }
 
-TEST(Radial, testRemoveDistortion) {
-  csm::ImageCoord imagePt(0.0, 4.0);
+TEST(Radial, testUndistortDistort) {
+  
+  // Distorted pixel
+  csm::ImageCoord imagePt(0.0, 1e-1);
 
+  // Undistort
   double ux, uy;
-  std::vector<double> coeffs = {0, 0, 0};
-
+  std::vector<double> coeffs = {0.03, 0.00001, 0.000004};
+  double tolerance = 1e-2;
   removeDistortion(imagePt.samp, imagePt.line, ux, uy, coeffs,
-                   DistortionType::RADIAL);
-
-  EXPECT_NEAR(ux, 4, 1e-8);
-  EXPECT_NEAR(uy, 0, 1e-8);
+                   DistortionType::RADIAL, tolerance);
+  
+  // Distort back
+  double desiredPrecision = 1e-6;
+  double dx, dy;
+  applyDistortion(ux, uy, dx, dy, coeffs,
+                  DistortionType::RADIAL, desiredPrecision, tolerance);
+  
+  EXPECT_NEAR(dx, imagePt.samp, 1e-8);
+  EXPECT_NEAR(dy, imagePt.line, 1e-8);
 }
 
 // If coeffs are 0 then this will have the same result as removeDistortion


### PR DESCRIPTION
This is a proposed fix to https://github.com/DOI-USGS/usgscsm/issues/461.

The issue here is that with the unmodified code the radial distortion and undistortion operations are not being applied when the pixel value is very close to the origin. 

Ironically, this is when distortion and undistortion is most likely to converge well, as, radial distortion this is just some multiplications and additions. Radial undistortion is about the same thing.

There is no division by a number close to zero anywhere where one should need to ensure a tolerance must be respected.

I modified the unit test to make it more realistic, by using non-zero distortion coefficients. Before the proposed fix, the test will fail, as distortion and undistortion are not true inverse of each other. That is because, before the fix, the distortion operation was applied, since the pixel value is above the tolerance, but the undistortion operation is not applied, since then the pixel value is below the tolerance.

With this fix, the distortion and undistortion are consistently applied close to the origin and this unit test passes.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

