### PR TITLE
Support for the radial + tangential distortion model

### DIFF
--- a/include/usgscsm/Distortion.h
+++ b/include/usgscsm/Distortion.h
@@ -6,7 +6,9 @@
 #include <tuple>
 #include <vector>
 
-enum DistortionType { RADIAL, TRANSVERSE, KAGUYALISM, DAWNFC, LROLROCNAC, CAHVOR, RADTAN };
+// This should be synched with the enum in ale/Distortion.h
+enum DistortionType { RADIAL, TRANSVERSE, KAGUYALISM, DAWNFC, LROLROCNAC, CAHVOR, 
+                     LUNARORBITER, RADTAN };
 
 // Transverse distortion Jacobian
 void transverseDistortionJacobian(double x, double y, double *jacobian,
@@ -23,6 +25,7 @@ void removeDistortion(double dx, double dy, double &ux, double &uy,
 void applyDistortion(double ux, double uy, double &dx, double &dy,
                      std::vector<double> const& opticalDistCoeffs,
                      DistortionType distortionType,
-                     const double desiredPrecision = 1.0E-6,
+                     const double desiredPrecisio
+                     n = 1.0E-6,
                      const double tolerance = 1.0E-6);
 #endif  // INCLUDE_USGSCSM_DISTORTION_H_

--- a/include/usgscsm/Distortion.h
+++ b/include/usgscsm/Distortion.h
@@ -25,7 +25,6 @@ void removeDistortion(double dx, double dy, double &ux, double &uy,
 void applyDistortion(double ux, double uy, double &dx, double &dy,
                      std::vector<double> const& opticalDistCoeffs,
                      DistortionType distortionType,
-                     const double desiredPrecisio
-                     n = 1.0E-6,
+                     const double desiredPrecision = 1.0E-6,
                      const double tolerance = 1.0E-6);
 #endif  // INCLUDE_USGSCSM_DISTORTION_H_

--- a/include/usgscsm/Distortion.h
+++ b/include/usgscsm/Distortion.h
@@ -6,11 +6,11 @@
 #include <tuple>
 #include <vector>
 
-enum DistortionType { RADIAL, TRANSVERSE, KAGUYALISM, DAWNFC, LROLROCNAC, CAHVOR };
+enum DistortionType { RADIAL, TRANSVERSE, KAGUYALISM, DAWNFC, LROLROCNAC, CAHVOR, RADTAN };
 
-// Transverse Distortion
-void distortionJacobian(double x, double y, double *jacobian,
-                        const std::vector<double> opticalDistCoeffs);
+// Transverse distortion Jacobian
+void transverseDistortionJacobian(double x, double y, double *jacobian,
+                                  const std::vector<double> opticalDistCoeffs);
 
 void computeTransverseDistortion(double ux, double uy, double &dx, double &dy,
                                  const std::vector<double> opticalDistCoeffs);

--- a/include/usgscsm/Distortion.h
+++ b/include/usgscsm/Distortion.h
@@ -10,18 +10,18 @@ enum DistortionType { RADIAL, TRANSVERSE, KAGUYALISM, DAWNFC, LROLROCNAC, CAHVOR
 
 // Transverse distortion Jacobian
 void transverseDistortionJacobian(double x, double y, double *jacobian,
-                                  const std::vector<double> opticalDistCoeffs);
+                                  std::vector<double> const& opticalDistCoeffs);
 
 void computeTransverseDistortion(double ux, double uy, double &dx, double &dy,
-                                 const std::vector<double> opticalDistCoeffs);
+                                 std::vector<double> const& opticalDistCoeffs);
 
 void removeDistortion(double dx, double dy, double &ux, double &uy,
-                      const std::vector<double> opticalDistCoeffs,
+                      std::vector<double> const& opticalDistCoeffs,
                       DistortionType distortionType,
                       const double tolerance = 1.0E-6);
 
 void applyDistortion(double ux, double uy, double &dx, double &dy,
-                     const std::vector<double> opticalDistCoeffs,
+                     std::vector<double> const& opticalDistCoeffs,
                      DistortionType distortionType,
                      const double desiredPrecision = 1.0E-6,
                      const double tolerance = 1.0E-6);

--- a/include/usgscsm/Utilities.h
+++ b/include/usgscsm/Utilities.h
@@ -65,6 +65,15 @@ void lagrangeInterp(const int &numTime, const double *valueArray,
 double brentRoot(double lowerBound, double upperBound,
                  std::function<double(double)> func, double epsilon = 1e-10);
 
+// Use the Newton-Raphson method undistort a pixel (dx, dy), producing (ux, uy).
+void newtonRaphson(double dx, double dy, double &ux, double &uy,
+                    std::vector<double> const& opticalDistCoeffs,
+                    DistortionType distortionType, const double tolerance,
+                    std::function<void(double, double, double &, double &,
+                                       std::vector<double> const&)> distortionFunction,
+                    std::function<void(double, double, double *, 
+                                       std::vector<double> const&)> distortionJacobian);
+
 // Evaluate a polynomial function.
 // Coefficients should be ordered least order to greatest I.E. {1, 2, 3} is 1 +
 // 2x + 3x^2

--- a/src/Utilities.cpp
+++ b/src/Utilities.cpp
@@ -1060,9 +1060,9 @@ double getSemiMinorRadius(json isd, csm::WarningList *list) {
 // type. Defaults to transverse
 DistortionType getDistortionModel(json isd, csm::WarningList *list) {
   try {
-    json distoriton_subset = isd.at("optical_distortion");
+    json distortion_subset = isd.at("optical_distortion");
 
-    json::iterator it = distoriton_subset.begin();
+    json::iterator it = distortion_subset.begin();
 
     std::string distortion = (std::string)it.key();
 
@@ -1076,6 +1076,12 @@ DistortionType getDistortionModel(json isd, csm::WarningList *list) {
       return DistortionType::DAWNFC;
     } else if (distortion.compare("lrolrocnac") == 0) {
       return DistortionType::LROLROCNAC;
+    } else if (distortion.compare("cahvor") == 0) {
+      return DistortionType::CAHVOR;
+    } else if (distortion.compare("lunarorbiter") == 0) {
+      return DistortionType::LUNARORBITER;
+    } else if (distortion.compare("radtan") == 0) {
+      return DistortionType::RADTAN;
     }
   } catch (...) {
     if (list) {
@@ -1105,6 +1111,10 @@ DistortionType getDistortionModel(int aleDistortionModel,
       return DistortionType::LROLROCNAC;
     }else if (aleDistortionType == ale::DistortionType::CAHVOR) {
       return DistortionType::CAHVOR;
+    }else if (aleDistortionType == ale::DistortionType::LUNARORBITER) {
+      return DistortionType::LUNARORBITER;
+    }else if (aleDistortionType == ale::DistortionType::RADTAN) {
+      return DistortionType::RADTAN;
     }
   } catch (...) {
     if (list) {
@@ -1263,7 +1273,26 @@ std::vector<double> getDistortionCoeffs(json isd, csm::WarningList *list) {
         coefficients = std::vector<double>(6, 0.0);
       }
     } break;
+    case DistortionType::RADTAN: {
+      try {
+        coefficients = isd.at("optical_distortion")
+                           .at("radtan")
+                           .at("coefficients")
+                           .get<std::vector<double>>();
+
+        return coefficients;
+      } catch (...) {
+        if (list) {
+          list->push_back(csm::Warning(
+              csm::Warning::DATA_NOT_AVAILABLE,
+              "Could not parse the radtan distortion model coefficients.",
+              "Utilities::getDistortion()"));
+        }
+        coefficients = std::vector<double>(5, 0.0);
+      }
+    } break;
   }
+  
   if (list) {
     list->push_back(
         csm::Warning(csm::Warning::DATA_NOT_AVAILABLE,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,7 +33,6 @@ add_test(NAME test_usgscsm_cam_test_load_state
     COMMAND usgscsm_cam_test --model model_state.json --output-model-state model_state2.json
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests)
 
-
 # 3. Save model state from .sup file
 add_test(NAME test_usgscsm_cam_test_save_sup_state
     COMMAND usgscsm_cam_test --model data/gxp_model_file.sup --output-model-state gxp_model_state.json
@@ -43,4 +42,9 @@ add_test(NAME test_usgscsm_cam_test_load_sup_state
     COMMAND usgscsm_cam_test --model gxp_model_state.json --output-model-state gxp_model_state2.json
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests)
 
+# 5. Test the radtan model (this distortion model gets added to a DawnFC sensor)
+add_test(NAME test_usgscsm_cam_test_radtan
+    COMMAND usgscsm_cam_test --model data/dawnfc_radtan.json  --sample-rate 100 --output-model-state dawnfc_radtan_model_state.json
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests)
+    
 gtest_discover_tests(runCSMCameraModelTests WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests)

--- a/tests/DistortionTests.cpp
+++ b/tests/DistortionTests.cpp
@@ -19,8 +19,8 @@ TEST_P(ImageCoordParameterizedTest, JacobianTest) {
 
   csm::ImageCoord imagePt = GetParam();
   double jacobian[4];
-  distortionJacobian(imagePt.samp, imagePt.line, jacobian,
-                     transverseDistortionCoeffs);
+  transverseDistortionJacobian(imagePt.samp, imagePt.line, jacobian,
+                               transverseDistortionCoeffs);
 
   // Jxx * Jyy - Jxy * Jyx
   double determinant =
@@ -36,8 +36,8 @@ TEST(Transverse, Jacobian1) {
       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0};
 
   double jacobian[4];
-  distortionJacobian(imagePt.samp, imagePt.line, jacobian,
-                     transverseDistortionCoeffs);
+  transverseDistortionJacobian(imagePt.samp, imagePt.line, jacobian,
+                               transverseDistortionCoeffs);
 
   EXPECT_NEAR(jacobian[0], 56.25, 1e-8);
   EXPECT_NEAR(jacobian[1], 112.5, 1e-8);
@@ -379,4 +379,29 @@ TEST_P(CoeffOffsetParameterizedTest, InverseOnesCoeffsCahvorTest)
 
   EXPECT_NEAR(dx, 4, 1e-8);
   EXPECT_NEAR(dy, 0, 1e-8);
+}
+
+INSTANTIATE_TEST_SUITE_P(RadTanInversionTest, RadTanTest,
+                         ::testing::Values(std::vector<double>(0, 0)));
+
+TEST_P(RadTanTest, RadTanInversionTest)
+{
+
+  // Initialize radtan distortion coefficients (k1, k2, p1, p2, k3)  
+  std::vector<double> distCoeffs= {0.000031, -0.000056, 1.3e-5, -1.7e-6, 2.9e-8};
+  
+  double ux = 5.0, uy = 6.0; 
+  
+  // Compute distortion 
+  double dx, dy;
+  applyDistortion(ux, uy, dx, dy, distCoeffs, DistortionType::RADTAN, 1e-8, 1e-8);
+  
+  // Remove distortion (undistort)
+  double ux2, uy2;
+  removeDistortion(dx, dy, ux2, uy2, distCoeffs, DistortionType::RADTAN, 1e-8);
+  
+  EXPECT_NEAR(dx, 4.0010785450000004, 1e-8);
+  EXPECT_NEAR(dy, 4.8022116940000013, 1e-8);
+  EXPECT_NEAR(ux2, ux, 1e-8);
+  EXPECT_NEAR(uy2, uy, 1e-8);
 }

--- a/tests/Fixtures.h
+++ b/tests/Fixtures.h
@@ -180,6 +180,9 @@ class ImageCoordParameterizedTest
 class CoeffOffsetParameterizedTest
     : public ::testing::TestWithParam<std::vector<double>> {};
 
+class RadTanTest
+    : public ::testing::TestWithParam<std::vector<double>> {};
+
 class FramerParameterizedTest
     : public ::testing::TestWithParam<csm::ImageCoord> {
  protected:

--- a/tests/data/dawnfc_radtan.json
+++ b/tests/data/dawnfc_radtan.json
@@ -1,0 +1,272 @@
+{
+  "isis_camera_version": 2,
+  "image_lines": 1024,
+  "image_samples": 1024,
+  "name_platform": "DAWN",
+  "name_sensor": "FRAMING CAMERA 2",
+  "reference_height": {
+    "maxheight": 1000,
+    "minheight": -1000,
+    "unit": "m"
+  },
+  "name_model": "USGS_ASTRO_FRAME_SENSOR_MODEL",
+  "center_ephemeris_time": 366389046.66804266,
+  "radii": {
+    "semimajor": 289.0,
+    "semiminor": 229.0,
+    "unit": "km"
+  },
+  "body_rotation": {
+    "time_dependent_frames": [
+      2000004,
+      1
+    ],
+    "ck_table_start_time": 366389046.66804266,
+    "ck_table_end_time": 366389046.66804266,
+    "ck_table_original_size": 1,
+    "ephemeris_times": [
+      366389046.66804266
+    ],
+    "quaternions": [
+      [
+        -0.6516990183788688,
+        0.4029902779213469,
+        -0.03888879053873084,
+        0.641385131816547
+      ]
+    ],
+    "angular_velocities": [
+      [
+        0.00015233084023562592,
+        -0.00018790495501866476,
+        0.00021960595804307437
+      ]
+    ],
+    "reference_frame": 1
+  },
+  "instrument_pointing": {
+    "time_dependent_frames": [
+      -203120,
+      -203000,
+      1
+    ],
+    "ck_table_start_time": 366389046.66804266,
+    "ck_table_end_time": 366389046.66804266,
+    "ck_table_original_size": 1,
+    "ephemeris_times": [
+      366389046.66804266
+    ],
+    "quaternions": [
+      [
+        0.23666091236048983,
+        -0.2808008347085259,
+        -0.9120764329484655,
+        0.18237073298010004
+      ]
+    ],
+    "angular_velocities": [
+      [
+        -2.4291478000490343e-05,
+        -8.625645496100273e-06,
+        8.501230573671002e-06
+      ]
+    ],
+    "reference_frame": 1,
+    "constant_frames": [
+      -203121,
+      -203120
+    ],
+    "constant_rotation": [
+      1.0,
+      0.0,
+      0.0,
+      0.0,
+      1.0,
+      0.0,
+      0.0,
+      0.0,
+      1.0
+    ]
+  },
+  "naif_keywords": {
+    "BODY2000004_RADII": [
+      289.0,
+      280.0,
+      229.0
+    ],
+    "BODY_FRAME_CODE": 2000004,
+    "BODY_CODE": 2000004,
+    "FRAME_-203121_CLASS_ID": -203121.0,
+    "TKFRAME_-203121_ANGLES": [
+      0.0,
+      0.0,
+      0.0
+    ],
+    "INS-203121_PIXEL_SAMPLES": 1024.0,
+    "FRAME_-203121_CENTER": -203.0,
+    "INS-203121_FOV_ANGULAR_SIZE": [
+      0.09548,
+      0.09542
+    ],
+    "INS-203121_RAD_DIST_COEFF": 8.4e-06,
+    "INS-203121_FOV_ANGLE_UNITS": "DEGREES",
+    "TKFRAME_-203121_AXES": [
+      1.0,
+      2.0,
+      3.0
+    ],
+    "TKFRAME_-203121_SPEC": "ANGLES",
+    "INS-203121_IFOV": [
+      9.3242e-05,
+      9.3184e-05
+    ],
+    "FRAME_-203121_NAME": "DAWN_FC2_FILTER_1",
+    "INS-203121_F/RATIO": 7.5,
+    "INS-203121_EFF_WAVELENGTH": 732.0,
+    "INS-203121_PIXEL_SIZE": [
+      14.004,
+      13.995
+    ],
+    "INS-203121_BANDCENTER": 735.0,
+    "INS-203121_FOV_CLASS_SPEC": "ANGLES",
+    "FRAME_-203121_CLASS": 4.0,
+    "INS-203121_FOV_REF_VECTOR": [
+      1.0,
+      0.0,
+      0.0
+    ],
+    "INS-203121_FOV_CROSS_ANGLE": 2.7335816,
+    "INS-203121_FOV_REF_ANGLE": 2.7353005,
+    "INS-203121_BANDWIDTH": 682.0,
+    "INS-203121_CCD_CENTER": [
+      511.5,
+      511.5
+    ],
+    "TKFRAME_-203121_UNITS": "DEGREES",
+    "INS-203121_BORESIGHT": [
+      0.0,
+      0.0,
+      150.07
+    ],
+    "INS-203121_PIXEL_LINES": 1024.0,
+    "INS-203121_FOV_SHAPE": "RECTANGLE",
+    "INS-203121_FOCAL_LENGTH": 150.07,
+    "INS-203121_ITRANSL": [
+      0.0,
+      0.0,
+      71.42857142857143
+    ],
+    "INS-203121_TRANSX": [
+      0.0,
+      0.0140088,
+      0.0
+    ],
+    "INS-203121_TRANSY": [
+      0.0,
+      0.0,
+      0.014
+    ],
+    "INS-203121_ITRANSS": [
+      0.0,
+      71.38370167323397,
+      0.0
+    ],
+    "TKFRAME_-203121_RELATIVE": "DAWN_FC2",
+    "INS-203121_FOV_FRAME": "DAWN_FC2",
+    "BODY2000004_LONG_AXIS": 0.0,
+    "FRAME_2000004_CENTER": 2000004.0,
+    "FRAME_2000004_CLASS_ID": 2000004.0,
+    "BODY2000004_POLE_DEC": [
+      42.235,
+      0.0,
+      0.0
+    ],
+    "BODY2000004_PM": [
+      285.39,
+      1617.3329428,
+      0.0
+    ],
+    "BODY2000004_POLE_RA": [
+      309.031,
+      0.0,
+      0.0
+    ],
+    "OBJECT_2000004_FRAME": "VESTA_FIXED",
+    "FRAME_2000004_CLASS": 2.0,
+    "FRAME_2000004_NAME": "VESTA_FIXED"
+  },
+  "detector_sample_summing": 1,
+  "detector_line_summing": 1,
+  "focal_length_model": {
+    "focal_length": 150.07
+  },
+  "detector_center": {
+    "line": 512.0,
+    "sample": 512.0
+  },
+  "starting_detector_line": 0,
+  "starting_detector_sample": 0,
+  "focal2pixel_lines": [
+    0.0,
+    0.0,
+    71.40816909454442
+  ],
+  "focal2pixel_samples": [
+    0.0,
+    71.40816909454442,
+    0.0
+  ],
+  "optical_distortion": {
+    "radtan": {
+      "coefficients": [
+        8.4e-06, 0, 0, 0, 0
+      ]
+    }
+  },
+  "instrument_position": {
+    "spk_table_start_time": 366389046.66804266,
+    "spk_table_end_time": 366389046.66804266,
+    "spk_table_original_size": 1,
+    "ephemeris_times": [
+      366389046.66804266
+    ],
+    "positions": [
+      [
+        -980.0261618498736,
+        1388.7080325894044,
+        2466.5530852201077
+      ]
+    ],
+    "velocities": [
+      [
+        -0.038273210022520744,
+        0.04959477604204062,
+        -0.04302704368708845
+      ]
+    ],
+    "reference_frame": 1
+  },
+  "sun_position": {
+    "spk_table_start_time": 366389046.66804266,
+    "spk_table_end_time": 366389046.66804266,
+    "spk_table_original_size": 1,
+    "ephemeris_times": [
+      366389046.66804266
+    ],
+    "positions": [
+      [
+        -235084739.21033305,
+        210948757.04546872,
+        114748421.64433399
+      ]
+    ],
+    "velocities": [
+      [
+        -15.345047951161861,
+        -12.985834298998117,
+        -3.1660155049823224
+      ]
+    ],
+    "reference_frame": 1
+  }
+}


### PR DESCRIPTION
Add support for the radial + tangential distortion model. This has 5 distortion coefficients, stored in order k1, k2, p1, p2, k3. The k1, k2, k3 coefficients are for radial distortion, and p1 and p2 for tangential distortion. This was validated with the OpenCV implementation using the function cv::projectPoints().

Corresponding code was added in "ale" (https://github.com/DOI-USGS/ale/pull/575). 

The issue discussing this: https://github.com/DOI-USGS/usgscsm/issues/465

Tests were added for:

 - Ensuring distortion and undistortion are inverse to each other
 - Loading an ISD and running image-to-ground and ground-to-image operations, and saving a state file. The ISD was obtained from a DawnFC example by replacing the DawnFC distortion (which is only radial with one coefficient) by the larger set of distortion coefficients which just get appended to the existing coefficient.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law. 

