### PR TITLE
2.0.1 prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ release.
 
 ## [Unreleased]
 
+## [2.0.1] - 2024-01-23
+
+### Changed
+- Updated USGSCSM build process to internally build dependencies into the library with no linking. [#445](https://github.com/DOI-USGS/usgscsm/pull/445)
+
 ## [2.0.0] - 2024-01-05
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(usgscsm VERSION 2.0.0 DESCRIPTION "usgscsm library")
+project(usgscsm VERSION 2.0.1 DESCRIPTION "usgscsm library")
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 

--- a/code.json
+++ b/code.json
@@ -41,6 +41,43 @@
     "name": "USGSCSM",
     "organization": "U.S. Geological Survey",
     "description": "GitHub respository for the CSM compliant sensor models create by the USGS Astrogeology Science Center",
+    "version": "2.0.1",
+    "status": "Production",
+    "permissions": {
+      "usageType": "openSource",
+      "licenses": [
+        {
+          "name": "Public Domain, CC-1.0",
+          "URL": "https://code.usgs.gov/astrogeology/usgscsm/-/raw/2.0.1/LICENSE.md"
+        }
+      ]
+    },
+    "homepageURL": "https://code.usgs.gov/astrogeology/usgscsm/-/tree/2.0.1",
+    "downloadURL": "https://code.usgs.gov/astrogeology/usgscsm/-/archive/2.0.1/usgscsm-2.0.1.zip",
+    "disclaimerURL": "https://code.usgs.gov/astrogeology/usgscsm/-/raw/2.0.1/DISCLAIMER.md",
+    "repositoryURL": "https://code.usgs.gov/astrogeology/usgscsm.git",
+    "vcs": "git",
+    "laborHours": 60,
+    "tags": [
+      "Planetary",
+      "Remote Sensing",
+      "Data Processing",
+      "Community Sensor Model"
+    ],
+    "languages": [
+      "C++"
+    ],
+    "contact": {
+      "name": "Adam Paquette",
+      "email": "acpaquette@usgs.gov"
+    },
+    "date": {
+      "metadataLastUpdated": "2024-01-23"
+    }
+  }, {
+    "name": "USGSCSM",
+    "organization": "U.S. Geological Survey",
+    "description": "GitHub respository for the CSM compliant sensor models create by the USGS Astrogeology Science Center",
     "version": "2.0.0",
     "status": "Production",
     "permissions": {

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 
 {% set name = "usgscsm" %}
-{% set version = "main" %}
+{% set version = "2.0.1" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 
 {% set name = "usgscsm" %}
-{% set version = "2.0.1" %}
+{% set version = "main" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
Updates USGSCSM for a 2.0.1 release. Does not touch the meta.yaml as the builds come from the conda-forge feedstock.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

