### PR TITLE
Json Header Install Fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -624,8 +624,12 @@ else()
   set(PROJ_INCLUDE_DIR /PROJ)
 
   # Nlohmann JSON
-  set(JSON_BuildTests OFF CACHE INTERNAL "")
-  add_subdirectory(json)
+  add_library (nlohmann_json INTERFACE)
+  add_library (nlohmann_json::nlohmann_json ALIAS nlohmann_json)
+  target_include_directories (nlohmann_json INTERFACE
+                              $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/json/include>
+                              $<INSTALL_INTERFACE:include>)
+  set(NLOHMANN_JSON_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/json/include)
 
   # ALE
   # Use Eigen included with ALE
@@ -663,6 +667,7 @@ else()
   target_link_libraries(ale PRIVATE ${ALE_LINKS})
   set(ALE_TARGET ale)
   set(USGSCSM_INCLUDE_DIRS "${USGSCSM_INCLUDE_DIRS}"
+                           "${NLOHMANN_JSON_INCLUDE_DIR}"
                            "${CMAKE_CURRENT_SOURCE_DIR}/ale/include"
                            "${CMAKE_CURRENT_SOURCE_DIR}/PROJ/include"
   )


### PR DESCRIPTION
Fixed json headers being installed along side usgscsm and potentially overwriting other json installs

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

