### PR TITLE
license typo fix: BDS 3 -> BSD 3

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -8,7 +8,7 @@ https://www.usgs.gov/information-policies-and-instructions/copyrights-and-credit
 
 Several files in this project were originally developed and are copyrighted by
 BAE Systems Information and Electronic Systems Integration Inc. They are licensed
-under the BDS 3 clause license and have comments identifying this at the top.
+under the BSD 3 clause license and have comments identifying this at the top.
 
 It also contains materials from contributors that have waived their
 copyright interest to the public domain.


### PR DESCRIPTION
This is a simple typo fix in the LICENSE.md file where BDS 3 was mistakenly put instead of BSD 3; closes #450.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

