### PR TITLE
Use image center when computing flying height

### DIFF
--- a/src/UsgsAstroLsSensorModel.cpp
+++ b/src/UsgsAstroLsSensorModel.cpp
@@ -629,8 +629,10 @@ void UsgsAstroLsSensorModel::updateState() {
       "based on dx {} dy {} dz {}",
       m_gsd, dx, dy, dz)
 
-  // Compute flying height
-  csm::EcefCoord sensorPos = getSensorPosition(0.0);
+  // Compute the flying height. Use the center of the image, as for
+  // m_referencePointXyz and m_gsd.
+  ip = csm::ImageCoord(lineCtr, sampCtr);
+  csm::EcefCoord sensorPos = getSensorPosition(ip);
   dx = sensorPos.x - m_referencePointXyz.x;
   dy = sensorPos.y - m_referencePointXyz.y;
   dz = sensorPos.z - m_referencePointXyz.z;


### PR DESCRIPTION
When a CSM linescan model is loaded, some auxiliary info is computed, including the GSD, reference point, and flying height. 

All but the last one use the image center (half image dimensions) for the computations. But the flying height uses time 0. Time 0 is not well-defined for a linescan sensor. One should use either the starting time as set in the metadata, or the time at starting line, or some time that is relevant to the given sensor.

I ran into this when creating custom linescan models. The resulting flying height then ends up being quite off, depending on what the starting time is.

The proposed fix uses the image center time to find the flying height, for consistency with GSD and reference point calculations.

The effect of this fix in practice is very small, unless one does unusual things.

Looks like all tests still pass after the fix.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

