### PR TITLE
Ensure usgscsm_cam_test can find libusgscsm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ include(GNUInstallDirs)
 
 set(CMAKE_CXX_STANDARD 14)
 
+# For dependencies minimum version
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+
 # Set a default build type if none was specified
 set(default_build_type "Release")
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ else()
     set(CMAKE_C_FLAGS "${_tmp_CMAKE_C_FLAGS}")
   endif()
 
-  # check needed include file
+  # check needed include file
   check_function_exists(localeconv HAVE_LOCALECONV)
   check_function_exists(strerror HAVE_STRERROR)
   if(NOT WIN32)
@@ -713,6 +713,15 @@ target_link_libraries(usgscsm_cam_test
 install(TARGETS usgscsm LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/csmplugins/)
 install(DIRECTORY ${USGSCSM_INSTALL_INCLUDE_DIRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(TARGETS usgscsm_cam_test RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# Ensure usgscsm_cam_test can find the library in csmplugins
+if(APPLE)
+  set_target_properties(usgscsm_cam_test PROPERTIES
+    INSTALL_RPATH "@loader_path/../${CMAKE_INSTALL_LIBDIR}/csmplugins")
+else()
+  set_target_properties(usgscsm_cam_test PROPERTIES
+    INSTALL_RPATH "$ORIGIN/../${CMAKE_INSTALL_LIBDIR}/csmplugins")
+endif()
 
 # Optional build tests
 option (USGSCSM_BUILD_TESTS "Build tests" ON)


### PR DESCRIPTION
This is a fix for the usgscsm_cam_test tool not being able to find libusgscsm, once it is installed in lib/csmplugins.

This was tested for Mac and Linux.

Also, on line 124 in CmakeLists.txt there was a Unicode whitespace that renders in binary in some editors, so I replaced with a plain whitespace.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

