### PR TITLE
Frame cam no bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ release.
 ## [Unreleased]
 
 ### Fixed
+- Removed boundary checks for Frame Sensor Model getSensorPosition [#492](https://github.com/DOI-USGS/usgscsm/pull/492)
 - Fixed CAHVOR model optical shifts by removing tolerance check [#488](https://github.com/DOI-USGS/usgscsm/issues/488)
 
 ## [2.0.1] - 2024-01-23

--- a/include/usgscsm/UsgsAstroFrameSensorModel.h
+++ b/include/usgscsm/UsgsAstroFrameSensorModel.h
@@ -118,7 +118,7 @@ class UsgsAstroFrameSensorModel : public csm::RasterGM,
    *
    * @return @b csm::EcefCoord Returns the body-fixed sensor position.
    *
-   * @throw csm::Error::BOUNDS "Image coordinate () out of bounds."
+   * @throw csm::Error::BOUNDS "Image time () out of bounds."
    */
   virtual csm::EcefCoord getSensorPosition(
       const csm::ImageCoord &imagePt) const;

--- a/src/UsgsAstroFrameSensorModel.cpp
+++ b/src/UsgsAstroFrameSensorModel.cpp
@@ -503,26 +503,13 @@ csm::EcefCoord UsgsAstroFrameSensorModel::getSensorPosition(
     spdlog::level::debug,
     "Accessing sensor position for image point {}, {}",
     imagePt.line, imagePt.samp);
-  // check if the image point is in range
-  if (imagePt.samp >= m_startingDetectorSample &&
-      imagePt.samp <= (m_startingDetectorSample + m_nSamples) &&
-      imagePt.line >= m_startingDetectorSample &&
-      imagePt.line <= (m_startingDetectorLine + m_nLines)) {
-    csm::EcefCoord sensorPosition;
-    sensorPosition.x = m_currentParameterValue[0];
-    sensorPosition.y = m_currentParameterValue[1];
-    sensorPosition.z = m_currentParameterValue[2];
+    
+  csm::EcefCoord sensorPosition;
+  sensorPosition.x = m_currentParameterValue[0];
+  sensorPosition.y = m_currentParameterValue[1];
+  sensorPosition.z = m_currentParameterValue[2];
 
-    return sensorPosition;
-  } else {
-    MESSAGE_LOG(
-        spdlog::level::err,
-        "ERROR: UsgsAstroFrameSensorModel::getSensorPosition: "
-        "Image Coordinate {},{} out of Bounds",
-        imagePt.line, imagePt.samp);
-    throw csm::Error(csm::Error::BOUNDS, "Image Coordinate out of Bounds",
-                     "UsgsAstroFrameSensorModel::getSensorPosition");
-  }
+  return sensorPosition;
 }
 
 csm::EcefCoord UsgsAstroFrameSensorModel::getSensorPosition(double time) const {

--- a/tests/FrameCameraTests.cpp
+++ b/tests/FrameCameraTests.cpp
@@ -533,7 +533,10 @@ TEST_F(FrameSensorModelLogging, GetSensorPositionPixel) {
 
 TEST_F(FrameSensorModelLogging, GetSensorPositionPixelExceedsBounds) {
   csm::ImageCoord imagePt(-1, -1);
-  sensorModel->getSensorPosition(imagePt);
+  csm::EcefCoord sensorPos = sensorModel->getSensorPosition(imagePt);
+  EXPECT_EQ(sensorPos.x, 1000);
+  EXPECT_EQ(sensorPos.y, 0);
+  EXPECT_EQ(sensorPos.z, 0);
 }
 
 TEST_F(FrameSensorModelLogging, GetSensorPositionTime) {

--- a/tests/FrameCameraTests.cpp
+++ b/tests/FrameCameraTests.cpp
@@ -531,6 +531,11 @@ TEST_F(FrameSensorModelLogging, GetSensorPositionPixel) {
   sensorModel->getSensorPosition(imagePt);
 }
 
+TEST_F(FrameSensorModelLogging, GetSensorPositionPixelExceedsBounds) {
+  csm::ImageCoord imagePt(-1, -1);
+  sensorModel->getSensorPosition(imagePt);
+}
+
 TEST_F(FrameSensorModelLogging, GetSensorPositionTime) {
   csm::ImageCoord imagePt(7.5, 7.5);
   double time = sensorModel->getImageTime(imagePt);


### PR DESCRIPTION
- Removed any checks at all for pixel boundary in UsgsAstroFrameSensorModel::getSensorPosition(imageCoord).
- Added a test to check a pixel exceeding the boundary.

Fixes #489 

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

