### PR TITLE
m_ephemerisTime should be double

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ release.
 ## [Unreleased]
 
 ### Fixed
+- Fix a bug in the Frame Sensor Model, the ephemeris time was rounded to it. [#497](https://github.com/DOI-USGS/usgscsm/pull/497)
 - Removed boundary checks for Frame Sensor Model getSensorPosition [#492](https://github.com/DOI-USGS/usgscsm/pull/492)
 - Fixed CAHVOR model optical shifts by removing tolerance check [#488](https://github.com/DOI-USGS/usgscsm/issues/488)
 

--- a/src/UsgsAstroFrameSensorModel.cpp
+++ b/src/UsgsAstroFrameSensorModel.cpp
@@ -1534,7 +1534,7 @@ void UsgsAstroFrameSensorModel::replaceModelState(
     m_focalLengthEpsilon = state.at("m_focalLengthEpsilon").get<double>();
     m_nLines = state.at("m_nLines").get<int>();
     m_nSamples = state.at("m_nSamples").get<int>();
-    m_ephemerisTime = state.at("m_ephemerisTime").get<int>();
+    m_ephemerisTime = state.at("m_ephemerisTime").get<double>();
     m_currentParameterValue =
         state.at("m_currentParameterValue").get<std::vector<double>>();
     m_ccdCenter = state.at("m_ccdCenter").get<std::vector<double>>();


### PR DESCRIPTION
The value of ephemeris time is in double precision, both in ISIS, ALE, and in USGSCSM, except for this one place, where it is cast to int. The effect is that a timestamp is saved as:

   "m_ephemerisTime": 717716358.0,

instead of a correct value such as:

   "m_ephemerisTime": 717716358.2862071,

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

