### PR TITLE
fixes incorrect J2000 time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ release.
 - Fix a bug in the Frame Sensor Model, the ephemeris time was rounded to it. [#497](https://github.com/DOI-USGS/usgscsm/pull/497)
 - Removed boundary checks for Frame Sensor Model getSensorPosition [#492](https://github.com/DOI-USGS/usgscsm/pull/492)
 - Fixed CAHVOR model optical shifts by removing tolerance check [#488](https://github.com/DOI-USGS/usgscsm/issues/488)
+- Fixed bug in ephemTimeToCalendarTime where J2000 was calculated as Jan 1, 2000 00:00:00 instead of Jan 1, 2000 12:00:00 [#498](https://github.com/DOI-USGS/usgscsm/pull/498)
 
 ## [2.0.1] - 2024-01-23
 

--- a/src/Utilities.cpp
+++ b/src/Utilities.cpp
@@ -2591,12 +2591,12 @@ void applyRotationTranslationToXyzVec(ale::Rotation const& r, ale::Vec3d const& 
 
 /**
  * @description Converts ephemeris time, given in seconds since January 1, 2000 
- * 12:00:00 AM GMT, to a calendar time string formatted as 
+ * 12:00:00 PM TT, to a calendar time string formatted as 
  * "YYYY-MM-DDTHH:MM:SSZ". The function accounts for the base time and converts 
  * the input ephemeris time to the equivalent calendar time in UTC.
  *
  * @param ephemTime The ephemeris time in seconds since the epoch 
- * (January 1, 2000 12:00:00 AM GMT).
+ * (January 1, 2000 12:00:00 PM TT).
  *
  * @return A string representing the calendar time in UTC format 
  * "YYYY-MM-DDTHH:MM:SSZ".
@@ -2606,7 +2606,7 @@ std::string ephemTimeToCalendarTime(double ephemTime) {
   // Care must be taken to not use mktime() or localtime() as their
   // precise value depends on if a location respects Daylight Savings Time.
 
-  std::time_t y2k = 946684800; // January 1, 2000 12:00:00 AM GMT
+  std::time_t y2k = 946728000; // January 1, 2000 12:00:00 PM TT
   std::time_t finalTime = ephemTime + y2k;
   char buffer[22];
   strftime(buffer, 22, "%Y-%m-%dT%H:%M:%SZ", std::gmtime(&finalTime));

--- a/tests/FrameCameraTests.cpp
+++ b/tests/FrameCameraTests.cpp
@@ -789,5 +789,5 @@ TEST_F(FrameSensorModelLogging, losEllipsoidIntersect) {
 
 TEST_F(OrbitalFrameSensorModel, ReferenceDateTime) {
   std::string date = sensorModel->getReferenceDateAndTime();
-  EXPECT_EQ(date, "2000-01-01T00:16:40Z");
+  EXPECT_EQ(date, "2000-01-01T12:16:40Z");
 }

--- a/tests/LineScanCameraTests.cpp
+++ b/tests/LineScanCameraTests.cpp
@@ -273,7 +273,7 @@ TEST_F(OrbitalLineScanSensorModel, InversionReallyHigh) {
 
 TEST_F(OrbitalLineScanSensorModel, ReferenceDateTime) {
   std::string date = sensorModel->getReferenceDateAndTime();
-  EXPECT_EQ(date, "2000-01-01T00:16:39Z");
+  EXPECT_EQ(date, "2000-01-01T12:16:39Z");
 }
 
 TEST_F(FlippedOrbitalLineScanSensorModel, OppositeFlightDetector) {

--- a/tests/SarTests.cpp
+++ b/tests/SarTests.cpp
@@ -220,5 +220,5 @@ TEST_F(SarSensorModel, adjustedPositionVelocity) {
 
 TEST_F(SarSensorModel, ReferenceDateTime) {
   std::string date = sensorModel->getReferenceDateAndTime();
-  EXPECT_EQ(date, "2020-08-16T08:52:18Z");
+  EXPECT_EQ(date, "2020-08-16T20:52:18Z");
 }

--- a/tests/UtilitiesTests.cpp
+++ b/tests/UtilitiesTests.cpp
@@ -622,7 +622,7 @@ TEST(UtilitiesTests, ephemTimeToCalendarTime) {
   double ephemTime = 0.0;
   std::string timeStr = ephemTimeToCalendarTime(ephemTime);
 
-  EXPECT_STREQ(timeStr.c_str(), "2000-01-01T00:00:00Z");
+  EXPECT_STREQ(timeStr.c_str(), "2000-01-01T12:00:00Z");
 }
 
 TEST(UtilitiesTests, fileReaderTest) {


### PR DESCRIPTION
## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

