### PR TITLE
Add isUsgsCsmIsd() and isUsgsCsmState() quick peek functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ release.
 
 ## [Unreleased]
 
+### Added
+- `isUsgsCsmIsd()` and `isUsgsCsmState()` quick string-scan helpers in `UsgsAstroPluginSupport` to identify ISD vs model state without full JSON parsing or model construction. [#502](https://github.com/DOI-USGS/usgscsm/pull/502)
+
 ### Fixed
 - Fix a bug in the Frame Sensor Model, the ephemeris time was rounded to it. [#497](https://github.com/DOI-USGS/usgscsm/pull/497)
 - Removed boundary checks for Frame Sensor Model getSensorPosition [#492](https://github.com/DOI-USGS/usgscsm/pull/492)

--- a/bin/usgscsm_cam_test.cc
+++ b/bin/usgscsm_cam_test.cc
@@ -168,19 +168,31 @@ bool loadCsmCameraModel(std::string const& model_file,
     return true;
   }
 
-  // Try to read the model as an ISD
-  csm::Isd isd(model_file);
-
-  // Read the model in a string, for potentially finding parsing the
-  // model state from it.
+  // Read the file into a string
   std::string model_state;
   if (!readFileInString(model_file, model_state))
     return false;
 
-  // Check if loading the model worked
-  bool success = false;
+  // Quick peek: if this is a JSON ISD, we know the model name without
+  // expensive trial-and-error. Construct only the matching model.
+  std::string isd_model_name;
+  if (isUsgsCsmIsd(model_state, isd_model_name)) {
+    std::cout << "Detected JSON ISD with model: " << isd_model_name << "\n";
+    csm::Isd isd(model_file);
+    UsgsAstroPlugin cameraPlugin;
+    csm::Model *csm = cameraPlugin.constructModelFromISD(isd, isd_model_name, NULL);
+    if (!csm) {
+      std::cerr << "Failed to construct model from ISD: " << model_file << ".\n";
+      return false;
+    }
+    model = std::shared_ptr<csm::RasterGM>(dynamic_cast<csm::RasterGM*>(csm));
+    std::cout << "Loaded a CSM model of type " << isd_model_name
+              << " from ISD file " << model_file << ".\n";
+    return true;
+  }
 
-  // Try all detected plugins and all models for each plugin.
+  // Not an ISD. Try model state path (JSON state, .sup, etc.) via plugin iteration.
+  bool success = false;
   csm::PluginList plugins = csm::Plugin::getList();
   for (auto iter = plugins.begin(); iter != plugins.end(); iter++) {
 
@@ -196,14 +208,7 @@ bool loadCsmCameraModel(std::string const& model_file,
 
       std::string model_name = (*iter)->getModelName(i);
 
-      if (csm_plugin->canModelBeConstructedFromISD(isd, model_name, warnings)) {
-        // Try to construct the model from the ISD
-        csm = csm_plugin->constructModelFromISD(isd, model_name, warnings);
-        std::cout << "Loaded a CSM model of type " << model_name << " from ISD file "
-                  << model_file << ".\n";
-        success = true;
-      } else if (csm_plugin->canModelBeConstructedFromState(model_name, model_state, warnings)) {
-        // Try to construct it from the model state (handles .sup files)
+      if (csm_plugin->canModelBeConstructedFromState(model_name, model_state, warnings)) {
         csm = csm_plugin->constructModelFromState(model_state, warnings);
         std::cout << "Loaded a CSM model of type " << model_name
                   << " from model state file " << model_file << ".\n";

--- a/bin/usgscsm_cam_test.cc
+++ b/bin/usgscsm_cam_test.cc
@@ -191,63 +191,24 @@ bool loadCsmCameraModel(std::string const& model_file,
     return true;
   }
 
-  // Not an ISD. Try model state path (JSON state, .sup, etc.) via plugin iteration.
-  bool success = false;
-  csm::PluginList plugins = csm::Plugin::getList();
-  for (auto iter = plugins.begin(); iter != plugins.end(); iter++) {
-
-    const csm::Plugin* csm_plugin = (*iter);
-    std::cout << "Detected CSM plugin: " << csm_plugin->getPluginName()  << "\n";
-
-    size_t num_models = csm_plugin->getNumModels();
-    std::cout << "Number of models for this plugin: " << num_models << "\n";
-
-    csm::Model *csm = NULL;
-    csm::WarningList *warnings = new csm::WarningList;
-    for (size_t i = 0; i < num_models; i++) {
-
-      std::string model_name = (*iter)->getModelName(i);
-
-      if (csm_plugin->canModelBeConstructedFromState(model_name, model_state, warnings)) {
-        csm = csm_plugin->constructModelFromState(model_state, warnings);
-        std::cout << "Loaded a CSM model of type " << model_name
-                  << " from model state file " << model_file << ".\n";
-        success = true;
-      } else {
-        if (opt.verbose) {
-          std::string startStr = "<<<<<< Warnings from " + model_name + " <<<<<<";
-          std::cout << startStr << std::endl;
-          for (auto warning : *warnings)
-            std::cout << warning.getMessage() << std::endl;
-          std::string endStr(startStr.size(), '<');
-          std::cout << endStr << std::endl;
-        }
-        warnings->clear();
-        continue;
-      }
-
-      delete warnings;
-
-      csm::RasterGM *modelPtr = dynamic_cast<csm::RasterGM*>(csm);
-      if (modelPtr == NULL) {
-        // Normally earlier checks should be enough and this should not happen
-        std::cerr << "Could not load correctly a CSM model.\n";
-        return false;
-      } else {
-        // Assign to a smart pointer which will handle deallocation
-        model = std::shared_ptr<csm::RasterGM>(modelPtr);
-        std::cout << "Final model: " << model->getModelName() << std::endl;
-        break;
-      }
+  // Quick peek for model state (JSON state or .sup)
+  std::string state_model_name;
+  if (isUsgsCsmState(model_state, state_model_name)) {
+    std::cout << "Detected model state with model: " << state_model_name << "\n";
+    UsgsAstroPlugin cameraPlugin;
+    csm::Model *csm = cameraPlugin.constructModelFromState(model_state, NULL);
+    if (!csm) {
+      std::cerr << "Failed to construct model from state: " << model_file << ".\n";
+      return false;
     }
+    model = std::shared_ptr<csm::RasterGM>(dynamic_cast<csm::RasterGM*>(csm));
+    std::cout << "Loaded a CSM model of type " << state_model_name
+              << " from model state file " << model_file << ".\n";
+    return true;
   }
 
-  if (!success) {
-    std::cerr << "Failed to load a CSM model from: " << model_file << ".\n";
-    return false;
-  }
-
-  return true;
+  std::cerr << "Failed to load a CSM model from: " << model_file << ".\n";
+  return false;
 }
 
 bool updateSupModel(std::string& sup_string, std::string model) {

--- a/include/usgscsm/UsgsAstroPluginSupport.h
+++ b/include/usgscsm/UsgsAstroPluginSupport.h
@@ -9,5 +9,6 @@ csm::RasterGM *getUsgsCsmModelFromIsd(const std::string &stringIsd, const std::s
 csm::RasterGM *getUsgsCsmModelFromState(const std::string &stringState, const std::string &modelName, csm::WarningList *warnings);
 csm::RasterGM *getUsgsCsmModelFromJson(const nlohmann::json &j, const std::string &modelName, csm::WarningList *warnings);
 nlohmann::json getUsgsCsmModelJson(csm::RasterGM *model);
+bool isUsgsCsmIsd(const std::string &str, std::string &modelName);
 
 #endif // INCLUDE_USGSCSM_USGSASTROPLUGINSUPPORT_H_

--- a/include/usgscsm/UsgsAstroPluginSupport.h
+++ b/include/usgscsm/UsgsAstroPluginSupport.h
@@ -10,5 +10,6 @@ csm::RasterGM *getUsgsCsmModelFromState(const std::string &stringState, const st
 csm::RasterGM *getUsgsCsmModelFromJson(const nlohmann::json &j, const std::string &modelName, csm::WarningList *warnings);
 nlohmann::json getUsgsCsmModelJson(csm::RasterGM *model);
 bool isUsgsCsmIsd(const std::string &str, std::string &modelName);
+bool isUsgsCsmState(const std::string &str, std::string &modelName);
 
 #endif // INCLUDE_USGSCSM_USGSASTROPLUGINSUPPORT_H_

--- a/src/UsgsAstroPluginSupport.cpp
+++ b/src/UsgsAstroPluginSupport.cpp
@@ -178,3 +178,33 @@ bool isUsgsCsmIsd(const std::string &str, std::string &modelName) {
   modelName = str.substr(pos + 1, end - pos - 1);
   return !modelName.empty();
 }
+
+// Quick check if the given string is a USGS CSM model state (JSON state or GXP
+// .sup format). If yes, extract the model name. No JSON parsing is done, just
+// raw string searches. Following the logic in stateAsJson() (Utilities.cpp),
+// skip to the first '{' to bypass any .sup preamble, then search within the
+// JSON portion only.
+bool isUsgsCsmState(const std::string &str, std::string &modelName) {
+  modelName.clear();
+
+  // Find the start of the JSON blob (skips .sup preamble if present)
+  auto brace = str.find_first_of("{");
+  if (brace == std::string::npos)
+    return false;
+
+  // Model state uses m_modelName; ISDs use name_model
+  if (str.find("\"m_modelName\"", brace) == std::string::npos)
+    return false;
+
+  // Extract the model name value
+  std::string prefix = "\"USGS_ASTRO_";
+  auto pos = str.find(prefix, brace);
+  if (pos == std::string::npos)
+    return false;
+  auto end = str.find("\"", pos + 1);
+  if (end == std::string::npos)
+    return false;
+
+  modelName = str.substr(pos + 1, end - pos - 1);
+  return !modelName.empty();
+}

--- a/src/UsgsAstroPluginSupport.cpp
+++ b/src/UsgsAstroPluginSupport.cpp
@@ -147,3 +147,34 @@ nlohmann::json getUsgsCsmModelJson(csm::RasterGM *model) {
   std::string aFunction = "UsgsAstroPluginSupport::getUsgsCsmModelJson()";
   throw csm::Error(aErrorType, aMessage, aFunction);
 }
+
+// Quick check if the given string is a USGS CSM JSON ISD (not a model state,
+// .sup, etc.). If yes, extract the model name. No JSON parsing is done, just
+// raw string searches.
+bool isUsgsCsmIsd(const std::string &str, std::string &modelName) {
+  modelName.clear();
+
+  // Model state strings have a text prefix before '{'. ISDs start with '{'.
+  auto pos = str.find_first_not_of(" \t\n\r");
+  if (pos == std::string::npos || str[pos] != '{')
+    return false;
+
+  // Check for ISD-only keys (never present in model state)
+  if (str.find("\"body_rotation\"") == std::string::npos)
+    return false;
+  if (str.find("\"instrument_position\"") == std::string::npos)
+    return false;
+
+  // Extract the name_model value. Search for the model name prefix
+  // which immediately follows the "name_model" key's value quote.
+  std::string prefix = "\"USGS_ASTRO_";
+  pos = str.find(prefix);
+  if (pos == std::string::npos)
+    return false;
+  auto end = str.find("\"", pos + 1);
+  if (end == std::string::npos)
+    return false;
+
+  modelName = str.substr(pos + 1, end - pos - 1);
+  return !modelName.empty();
+}

--- a/tests/PluginTests.cpp
+++ b/tests/PluginTests.cpp
@@ -1,6 +1,7 @@
 #include "UsgsAstroFrameSensorModel.h"
 #include "UsgsAstroLsSensorModel.h"
 #include "UsgsAstroPlugin.h"
+#include "UsgsAstroPluginSupport.h"
 
 #include <fstream>
 #include <sstream>
@@ -230,6 +231,25 @@ TEST_F(SarIsdTest, ConstructInvalidCamera) {
   } catch (...) {
     FAIL() << "Expected csm SENSOR_MODEL_NOT_CONSTRUCTIBLE error";
   }
+}
+
+TEST(IsUsgsCsmIsd, RecognizesIsd) {
+  // Minimal ISD signature: leading '{', the ISD-only keys body_rotation
+  // and instrument_position, and a USGS_ASTRO_* model name.
+  std::string s = R"({"body_rotation":[],"instrument_position":[],
+                      "name_model":"USGS_ASTRO_FRAME_SENSOR_MODEL"})";
+  std::string name;
+  EXPECT_TRUE(isUsgsCsmIsd(s, name));
+  EXPECT_EQ(name, "USGS_ASTRO_FRAME_SENSOR_MODEL");
+}
+
+TEST(IsUsgsCsmState, RecognizesState) {
+  // .sup-style: arbitrary preamble before '{', then JSON state with m_modelName.
+  std::string s = "GXP-state-preamble\n"
+                  "{\"m_modelName\":\"USGS_ASTRO_LINE_SCANNER_SENSOR_MODEL\"}";
+  std::string name;
+  EXPECT_TRUE(isUsgsCsmState(s, name));
+  EXPECT_EQ(name, "USGS_ASTRO_LINE_SCANNER_SENSOR_MODEL");
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
The usgscsm_cam_test tool has a very complex way of loading a model. 

First, it iterates over all plugins.  For each, it tries to construct an isd which does a lot of work. If it succeeds it constructs the isd (so repeat of before). If not in luck, it tires to construct state for each plugin, and if in luck, it again constructs the state.

This can be very slow and I suspect similar logic with first try to construct and then actually construct (so 2x the work) is in other places too.

This adds quick functions that scan the model string (avoiding both json parsing and model building). One function is an isd check, and second is a model state check (that covers .sup as well). On success it returns the needed id that is later used for actual construction.

If this is accepted, these functions could likely be used in other places too.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.