### PR TITLE
version tick for 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ release.
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-06-09
+
 ### Added
 - `isUsgsCsmIsd()` and `isUsgsCsmState()` quick string-scan helpers in `UsgsAstroPluginSupport` to identify ISD vs model state without full JSON parsing or model construction. [#502](https://github.com/DOI-USGS/usgscsm/pull/502)
 - Added the `KPLOSHADOWCAM` distortion type for the KPLO ShadowCam imager. [#505](https://github.com/DOI-USGS/usgscsm/pull/505)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(usgscsm VERSION 2.0.1 DESCRIPTION "usgscsm library")
+project(usgscsm VERSION 2.1.0 DESCRIPTION "usgscsm library")
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 

--- a/code.json
+++ b/code.json
@@ -41,6 +41,43 @@
     "name": "USGSCSM",
     "organization": "U.S. Geological Survey",
     "description": "GitHub respository for the CSM compliant sensor models create by the USGS Astrogeology Science Center",
+    "version": "2.1.0",
+    "status": "Production",
+    "permissions": {
+      "usageType": "openSource",
+      "licenses": [
+        {
+          "name": "Public Domain, CC-1.0",
+          "URL": "https://code.usgs.gov/astrogeology/usgscsm/-/raw/2.1.0/LICENSE.md"
+        }
+      ]
+    },
+    "homepageURL": "https://code.usgs.gov/astrogeology/usgscsm/-/tree/2.1.0",
+    "downloadURL": "https://code.usgs.gov/astrogeology/usgscsm/-/archive/2.1.0/usgscsm-2.1.0.zip",
+    "disclaimerURL": "https://code.usgs.gov/astrogeology/usgscsm/-/raw/2.1.0/DISCLAIMER.md",
+    "repositoryURL": "https://code.usgs.gov/astrogeology/usgscsm.git",
+    "vcs": "git",
+    "laborHours": 60,
+    "tags": [
+      "Planetary",
+      "Remote Sensing",
+      "Data Processing",
+      "Community Sensor Model"
+    ],
+    "languages": [
+      "C++"
+    ],
+    "contact": {
+      "name": "Kelvin Rodriguez",
+      "email": "krodriguez@usgs.gov"
+    },
+    "date": {
+      "metadataLastUpdated": "2026-06-09"
+    }
+  }, {
+    "name": "USGSCSM",
+    "organization": "U.S. Geological Survey",
+    "description": "GitHub respository for the CSM compliant sensor models create by the USGS Astrogeology Science Center",
     "version": "2.0.1",
     "status": "Production",
     "permissions": {


### PR DESCRIPTION
version bump

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

