### PR TITLE
Remove stale spdlog install reference

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -718,8 +718,7 @@ set(USGSCSM_INCLUDE_DIRS "${USGSCSM_INCLUDE_DIRS}"
                          "${PROJ_INCLUDE_DIR}")
 
 # These will be copied upon installation to ${CMAKE_INSTALL_INCLUDEDIR}/include
-set(USGSCSM_INSTALL_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include/usgscsm"
-                                 "${CMAKE_CURRENT_SOURCE_DIR}/include/spdlog")
+set(USGSCSM_INSTALL_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include/usgscsm")
 
 target_include_directories(usgscsm
                            PUBLIC


### PR DESCRIPTION
When spdlog was replaced by the built-in logger, the `include/spdlog` directory was removed but the corresponding entry in `USGSCSM_INSTALL_INCLUDE_DIRS` (CMakeLists.txt line 722) was not cleaned up. This causes `make install` to fail when building with `USGSCSM_EXTERNAL_DEPS=ON` because CMake tries to install a directory that no longer exists.

The fix removes the stale reference.

Disclaimer: this work was done with AI assistance (Claude).

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.