### PR TITLE
Default the log level to ERROR to avoid stalling high-volume callers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+- Changed the default log level from `INFO` to `ERROR` so high-volume callers are not stalled by per-call logging in `groundToImage`/`imageToGround`. The level is still overridable with the `USGSCSM_LOG_LEVEL` environment variable. [#514](https://github.com/DOI-USGS/usgscsm/pull/514)
+
 ## [2.1.0] - 2026-06-09
 
 ### Added

--- a/src/UsgsAstroPlugin.cpp
+++ b/src/UsgsAstroPlugin.cpp
@@ -78,8 +78,8 @@ UsgsAstroPlugin::UsgsAstroPlugin() {
     std::string logLevelStr(logLevelPtr);
     usgscsm::logger::set_log_level(usgscsm::logger::level_from_string(logLevelStr));
   } else {
-    // Default to INFO level
-    usgscsm::logger::set_log_level(usgscsm::logger::INFO);
+    // Default to ERROR level to avoid printing very frequently.
+    usgscsm::logger::set_log_level(usgscsm::logger::ERROR);
   }
 }
 


### PR DESCRIPTION
## Description

The plugin constructor sets the default log level to INFO when USGSCSM_LOG_LEVEL is not set. At INFO (or lower), groundToImage and imageToGround each emit a log message on every call, which formats a timestamped string and writes it to a shared output stream.

This caused problems in the ASP mapproject program, which calls groundToImage for every pixel in an image: the run sat at 0% CPU and did not complete, as the per-pixel logging serialized the work on the output stream.

This changes the default level to ERROR. ERROR-severity messages do not fire in the projection hot path, so the per-call cost collapses to a level check and the stall goes away. The level is still overridable through the USGSCSM_LOG_LEVEL environment variable.

Validation: with this default, the same mapproject run on a TGO CaSSIS image completes in a few seconds instead of not finishing.

Suggestion (not included here, to keep the change minimal): the per-call messages inside groundToImage and imageToGround are logged at INFO. They would be better as TRACE, so that a user who raises the level to INFO for setup diagnostics is still not affected by per-pixel logging.

This change was prepared with AI assistance (Claude).

## Licensing

This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
