### PR TITLE
Throw on an unknown lens distortion model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ release.
 - A `CASSIS` distortion type implementing the TGO CaSSIS rational ratio-of-quadratics distortion model, matching ISIS `TgoCassisDistortionMap`, with the json-name, ALE integer-enum, and coefficient-extraction dispatch wired in. Pairs with the ALE TGO CaSSIS driver. [#512](https://github.com/DOI-USGS/usgscsm/pull/512)
 
 ### Fixed
+- `applyDistortion` and `removeDistortion` now throw on a distortion type they do not handle instead of silently returning the point undistorted. This covers the `LUNARORBITER` type, which is declared and emitted by ALE but was never implemented here, and any type from a model state that this build does not recognize. Previously such a model was silently treated as distortion-free, producing wrong geometry with no warning. [#521](https://github.com/DOI-USGS/usgscsm/pull/521)
 - Changed the default log level from `INFO` to `ERROR` so high-volume callers are not stalled by per-call logging in `groundToImage`/`imageToGround`. The level is still overridable with the `USGSCSM_LOG_LEVEL` environment variable. [#514](https://github.com/DOI-USGS/usgscsm/pull/514)
 - The Windows build now produces and installs the `usgscsm` import library alongside `usgscsm.dll`, and `usgscsm_cam_test` links against it. Enabled `WINDOWS_EXPORT_ALL_SYMBOLS` on the `usgscsm` target, and added RUNTIME and ARCHIVE destinations to its install rule, which the previous `LIBRARY`-only tagging omitted on Windows. Unix behavior is unchanged. [#518](https://github.com/DOI-USGS/usgscsm/pull/518)
 

--- a/src/Distortion.cpp
+++ b/src/Distortion.cpp
@@ -463,6 +463,26 @@ void removeDistortion(double dx, double dy, double &ux, double &uy,
       return;
     } break;
 
+    // LUNARORBITER is a declared distortion type (emitted by ALE as
+    // "lunarorbiter") but its distortion math was never implemented here.
+    // Throw rather than fall through, which would silently apply no distortion.
+    case LUNARORBITER:
+      throw csm::Error(csm::Error::UNSUPPORTED_FUNCTION,
+                       "LUNARORBITER distortion is not implemented.",
+                       "removeDistortion");
+      break;
+
+    // An unrecognized distortion type must fail loudly. Falling through the
+    // switch would silently leave the point undistorted, hiding the fact that
+    // the model was not applied. This also guards against a model state that
+    // stores a distortion type this build does not know about.
+    default:
+      throw csm::Error(csm::Error::UNSUPPORTED_FUNCTION,
+                       "Unsupported distortion type: " +
+                           std::to_string(static_cast<int>(distortionType)),
+                       "removeDistortion");
+      break;
+
   }
 }
 
@@ -836,10 +856,30 @@ void applyDistortion(double ux, double uy, double &dx, double &dy,
     case RADTAN:
     {
       ux /= focalLength; uy /= focalLength; // Find normalized coordinates
-      computeRadTanDistortion(ux, uy, dx, dy, opticalDistCoeffs);  
+      computeRadTanDistortion(ux, uy, dx, dy, opticalDistCoeffs);
       dx *= focalLength; dy *= focalLength; // Convert back to pixel coordinates
-    }  
+    }
     break;
-    
+
+    // LUNARORBITER is a declared distortion type (emitted by ALE as
+    // "lunarorbiter") but its distortion math was never implemented here.
+    // Throw rather than fall through, which would silently apply no distortion.
+    case LUNARORBITER:
+      throw csm::Error(csm::Error::UNSUPPORTED_FUNCTION,
+                       "LUNARORBITER distortion is not implemented.",
+                       "applyDistortion");
+      break;
+
+    // An unrecognized distortion type must fail loudly. Falling through the
+    // switch would silently leave the point undistorted, hiding the fact that
+    // the model was not applied. This also guards against a model state that
+    // stores a distortion type this build does not know about.
+    default:
+      throw csm::Error(csm::Error::UNSUPPORTED_FUNCTION,
+                       "Unsupported distortion type: " +
+                           std::to_string(static_cast<int>(distortionType)),
+                       "applyDistortion");
+      break;
+
   }
 }

--- a/src/Distortion.cpp
+++ b/src/Distortion.cpp
@@ -463,19 +463,14 @@ void removeDistortion(double dx, double dy, double &ux, double &uy,
       return;
     } break;
 
-    // LUNARORBITER is a declared distortion type (emitted by ALE as
-    // "lunarorbiter") but its distortion math was never implemented here.
-    // Throw rather than fall through, which would silently apply no distortion.
+    // LUNARORBITER is declared and emitted by ALE but not implemented here.
     case LUNARORBITER:
       throw csm::Error(csm::Error::UNSUPPORTED_FUNCTION,
                        "LUNARORBITER distortion is not implemented.",
                        "removeDistortion");
       break;
 
-    // An unrecognized distortion type must fail loudly. Falling through the
-    // switch would silently leave the point undistorted, hiding the fact that
-    // the model was not applied. This also guards against a model state that
-    // stores a distortion type this build does not know about.
+    // Throw on an unrecognized distortion type instead of silently ignoring it.
     default:
       throw csm::Error(csm::Error::UNSUPPORTED_FUNCTION,
                        "Unsupported distortion type: " +
@@ -861,19 +856,14 @@ void applyDistortion(double ux, double uy, double &dx, double &dy,
     }
     break;
 
-    // LUNARORBITER is a declared distortion type (emitted by ALE as
-    // "lunarorbiter") but its distortion math was never implemented here.
-    // Throw rather than fall through, which would silently apply no distortion.
+    // LUNARORBITER is declared and emitted by ALE but not implemented here.
     case LUNARORBITER:
       throw csm::Error(csm::Error::UNSUPPORTED_FUNCTION,
                        "LUNARORBITER distortion is not implemented.",
                        "applyDistortion");
       break;
 
-    // An unrecognized distortion type must fail loudly. Falling through the
-    // switch would silently leave the point undistorted, hiding the fact that
-    // the model was not applied. This also guards against a model state that
-    // stores a distortion type this build does not know about.
+    // Throw on an unrecognized distortion type instead of silently ignoring it.
     default:
       throw csm::Error(csm::Error::UNSUPPORTED_FUNCTION,
                        "Unsupported distortion type: " +

--- a/tests/DistortionTests.cpp
+++ b/tests/DistortionTests.cpp
@@ -1,5 +1,6 @@
 #include "Distortion.h"
 
+#include <Error.h>
 #include <gtest/gtest.h>
 
 #include "Fixtures.h"
@@ -568,4 +569,40 @@ TEST(CassisMapping, intToEnum) {
   DistortionType dt =
       getDistortionModel(static_cast<int>(ale::DistortionType::CASSIS));
   EXPECT_EQ(dt, DistortionType::CASSIS);
+}
+
+TEST(UnsupportedDistortion, applyThrows) {
+  double dx, dy;
+  std::vector<double> coeffs;
+  // An out-of-range distortion type must throw, not silently pass the point
+  // through undistorted.
+  EXPECT_THROW(applyDistortion(10.0, 10.0, dx, dy, coeffs, 1000.0,
+                               static_cast<DistortionType>(999), 1e-7),
+               csm::Error);
+}
+
+TEST(UnsupportedDistortion, removeThrows) {
+  double ux, uy;
+  std::vector<double> coeffs;
+  EXPECT_THROW(removeDistortion(10.0, 10.0, ux, uy, coeffs, 1000.0,
+                                static_cast<DistortionType>(999), 1e-7),
+               csm::Error);
+}
+
+TEST(LunarOrbiter, applyThrows) {
+  double dx, dy;
+  std::vector<double> coeffs;
+  // LUNARORBITER is declared but its distortion math is unimplemented, so it
+  // must throw rather than silently apply no distortion.
+  EXPECT_THROW(applyDistortion(10.0, 10.0, dx, dy, coeffs, 1000.0,
+                               DistortionType::LUNARORBITER, 1e-7),
+               csm::Error);
+}
+
+TEST(LunarOrbiter, removeThrows) {
+  double ux, uy;
+  std::vector<double> coeffs;
+  EXPECT_THROW(removeDistortion(10.0, 10.0, ux, uy, coeffs, 1000.0,
+                                DistortionType::LUNARORBITER, 1e-7),
+               csm::Error);
 }

--- a/tests/DistortionTests.cpp
+++ b/tests/DistortionTests.cpp
@@ -574,8 +574,7 @@ TEST(CassisMapping, intToEnum) {
 TEST(UnsupportedDistortion, applyThrows) {
   double dx, dy;
   std::vector<double> coeffs;
-  // An out-of-range distortion type must throw, not silently pass the point
-  // through undistorted.
+  // Throw on an out-of-range distortion type.
   EXPECT_THROW(applyDistortion(10.0, 10.0, dx, dy, coeffs, 1000.0,
                                static_cast<DistortionType>(999), 1e-7),
                csm::Error);
@@ -592,8 +591,7 @@ TEST(UnsupportedDistortion, removeThrows) {
 TEST(LunarOrbiter, applyThrows) {
   double dx, dy;
   std::vector<double> coeffs;
-  // LUNARORBITER is declared but its distortion math is unimplemented, so it
-  // must throw rather than silently apply no distortion.
+  // LUNARORBITER is unimplemented, so it must throw.
   EXPECT_THROW(applyDistortion(10.0, 10.0, dx, dy, coeffs, 1000.0,
                                DistortionType::LUNARORBITER, 1e-7),
                csm::Error);


### PR DESCRIPTION
## Description

This makes applyDistortion and removeDistortion fail on a distortion type they do not know about.

This is a bugfix for an actual problem. An old usgscsm library read in a CSM camera for CaSSIS that it could not handle and quietly processed it with the wrong distortion model.

This also catches the fact that the lens distortion for LUNARORBITER is not implemented. Quetly using here the some model is likely not what is intended. 

Done with Claude/AI assistance. Thoroughly reviewed. 

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
