### PR TITLE
Remove CSM Submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "gtest"]
 	path = gtest
 	url = https://github.com/google/googletest
-[submodule "csm"]
-	path = csm
-	url = https://github.com/USGS-Astrogeology/csm
 [submodule "ale"]
 	path = ale
 	url = https://github.com/oleg-alexandrov/ale.git


### PR DESCRIPTION
After #519, USGSCSM must link against a CSM installation (from conda), and can no longer build with CSM internally included.

This PR removes the CSM Submodule, as CSM can no longer be used as a submodule in the build/make process.

This will cause test failures until updated, so leaving as a draft for now.  TODO:

- [ ] Update Tests

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

