### PR TITLE
Remove CSM submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "gtest"]
 	path = gtest
 	url = https://github.com/google/googletest
-[submodule "csm"]
-	path = csm
-	url = https://github.com/USGS-Astrogeology/csm
 [submodule "ale"]
 	path = ale
 	url = https://github.com/oleg-alexandrov/ale.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,8 +70,7 @@ set(USGSCSM_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include/usgscsm"
 )
 
 # CSM API library
-find_path(CSM_INCLUDE_DIR NAMES "csm.h"
-                          PATH_SUFFIXES "csm"
+find_path(CSM_INCLUDE_DIR NAMES "csm/csm.h"
                           PATHS $ENV{CONDA_PREFIX}/include/
                           REQUIRED)
 find_library(CSM_LIBRARY csmapi PATHS $ENV{CONDA_PREFIX}/lib REQUIRED)

--- a/bin/usgscsm_cam_test.cc
+++ b/bin/usgscsm_cam_test.cc
@@ -20,7 +20,7 @@
 //   and compare with the original pixel values.
 
 #include <UsgsAstroPlugin.h>
-#include <RasterGM.h>
+#include <csm/RasterGM.h>
 #include <UsgsAstroLsSensorModel.h>
 #include <Utilities.h>
 

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - ale>=0.8.8
   - cmake>=3.15,<4.0
   - csm >= 3.1.0
-  - eigen
+  - eigen >=3,<4
   - nlohmann_json
   - proj
   - sqlite>=3.11

--- a/include/usgscsm/EigenUtilities.h
+++ b/include/usgscsm/EigenUtilities.h
@@ -4,7 +4,7 @@
 // Do not include Eigen header files here as those will slow down the compilation
 // whereever this header file is included.
 
-#include <csm.h>
+#include <csm/csm.h>
 
 namespace usgscsm {
   

--- a/include/usgscsm/UsgsAstroFrameSensorModel.h
+++ b/include/usgscsm/UsgsAstroFrameSensorModel.h
@@ -8,10 +8,11 @@
 #include <memory>
 #include <string>
 
-#include "SettableEllipsoid.h"
-#include "CorrelationModel.h"
+#include <csm/SettableEllipsoid.h>
+#include <csm/CorrelationModel.h>
+#include <csm/RasterGM.h>
+
 #include "Distortion.h"
-#include "RasterGM.h"
 #include "Utilities.h"
 #include "VariantMap.h"
 

--- a/include/usgscsm/UsgsAstroLsSensorModel.h
+++ b/include/usgscsm/UsgsAstroLsSensorModel.h
@@ -25,9 +25,9 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
 #ifndef INCLUDE_USGSCSM_USGSASTROLSSENSORMODEL_H_
 #define INCLUDE_USGSCSM_USGSASTROLSSENSORMODEL_H_
 
-#include <CorrelationModel.h>
-#include <RasterGM.h>
-#include <SettableEllipsoid.h>
+#include <csm/CorrelationModel.h>
+#include <csm/RasterGM.h>
+#include <csm/SettableEllipsoid.h>
 #include "Distortion.h"
 #include "VariantMap.h"
 

--- a/include/usgscsm/UsgsAstroProjectedSensorModel.h
+++ b/include/usgscsm/UsgsAstroProjectedSensorModel.h
@@ -28,13 +28,13 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
 #ifndef __EMSCRIPTEN__
 // ProjectedSensorModel requires PROJ library which is not available in WASM builds
 
-#include <RasterGM.h>
-#include <SettableEllipsoid.h>
+#include <csm/RasterGM.h>
+#include <csm/SettableEllipsoid.h>
 
-#include<utility>
-#include<memory>
-#include<string>
-#include<vector>
+#include <utility>
+#include <memory>
+#include <string>
+#include <vector>
 
 #include "ale/Orientations.h"
 #include "ale/States.h"

--- a/include/usgscsm/UsgsAstroPushFrameSensorModel.h
+++ b/include/usgscsm/UsgsAstroPushFrameSensorModel.h
@@ -25,16 +25,16 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
 #ifndef INCLUDE_USGSCSM_USGSASTROPUSHFRAMESENSORMODEL_H_
 #define INCLUDE_USGSCSM_USGSASTROPUSHFRAMESENSORMODEL_H_
 
-#include <CorrelationModel.h>
-#include <RasterGM.h>
-#include <SettableEllipsoid.h>
+#include <csm/CorrelationModel.h>
+#include <csm/RasterGM.h>
+#include <csm/SettableEllipsoid.h>
 #include "Distortion.h"
 #include "VariantMap.h"
 
-#include<utility>
-#include<memory>
-#include<string>
-#include<vector>
+#include <utility>
+#include <memory>
+#include <string>
+#include <vector>
 
 #include "ale/Distortion.h"
 #include "ale/Orientations.h"

--- a/include/usgscsm/UsgsAstroSarSensorModel.h
+++ b/include/usgscsm/UsgsAstroSarSensorModel.h
@@ -1,9 +1,9 @@
 #ifndef __USGS_ASTRO_SAR_SENSORMODEL_H
 #define __USGS_ASTRO_SAR_SENSORMODEL_H
 
-#include <CorrelationModel.h>
-#include <RasterGM.h>
-#include <SettableEllipsoid.h>
+#include <csm/CorrelationModel.h>
+#include <csm/RasterGM.h>
+#include <csm/SettableEllipsoid.h>
 
 #include "ale/Rotation.h"
 #include "VariantMap.h"

--- a/include/usgscsm/Utilities.h
+++ b/include/usgscsm/Utilities.h
@@ -14,9 +14,9 @@
 #include <ale/Rotation.h>
 #include <ale/Vectors.h>
 
-#include <RasterGM.h>
-#include <Warning.h>
-#include <csm.h>
+#include <csm/RasterGM.h>
+#include <csm/Warning.h>
+#include <csm/csm.h>
 
 // Compute distorted focalPlane coordinates in mm
 void computeDistortedFocalPlaneCoordinates(

--- a/src/Distortion.cpp
+++ b/src/Distortion.cpp
@@ -1,7 +1,7 @@
 #include "Distortion.h"
 #include "Utilities.h"
 
-#include <Error.h>
+#include <csm/Error.h>
 #include <string>
 
 // TGO CaSSIS rational distortion helper. The model (Tulyakov/Ivanov, EPFL) is a

--- a/src/EigenUtilities.cpp
+++ b/src/EigenUtilities.cpp
@@ -1,6 +1,6 @@
 #include "EigenUtilities.h"
 
-#include <Error.h>
+#include <csm/Error.h>
 #include <Eigen/Dense>
 
 #include <iostream>

--- a/src/UsgsAstroLsSensorModel.cpp
+++ b/src/UsgsAstroLsSensorModel.cpp
@@ -34,7 +34,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
 #include <iostream>
 #include <sstream>
 
-#include <Error.h>
+#include <csm/Error.h>
 
 #include "ale/Util.h"
 

--- a/src/UsgsAstroProjectedSensorModel.cpp
+++ b/src/UsgsAstroProjectedSensorModel.cpp
@@ -32,7 +32,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
 
 #include <proj.h>
 
-#include <Error.h>
+#include <csm/Error.h>
 #include <nlohmann/json.hpp>
 
 #include "ale/Util.h"

--- a/src/UsgsAstroPushFrameSensorModel.cpp
+++ b/src/UsgsAstroPushFrameSensorModel.cpp
@@ -33,7 +33,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
 #include <iostream>
 #include <sstream>
 
-#include <Error.h>
+#include <csm/Error.h>
 #include <nlohmann/json.hpp>
 
 #include "ale/Util.h"

--- a/src/Utilities.cpp
+++ b/src/Utilities.cpp
@@ -1,6 +1,6 @@
 #include "Utilities.h"
 
-#include <Error.h>
+#include <csm/Error.h>
 #include <cmath>
 #include <stack>
 #include <stdexcept>

--- a/tests/DistortionTests.cpp
+++ b/tests/DistortionTests.cpp
@@ -1,6 +1,6 @@
 #include "Distortion.h"
 
-#include <Error.h>
+#include <csm/Error.h>
 #include <gtest/gtest.h>
 
 #include "Fixtures.h"

--- a/tests/SarTests.cpp
+++ b/tests/SarTests.cpp
@@ -3,7 +3,7 @@
 #include "UsgsAstroSarSensorModel.h"
 
 #include "Fixtures.h"
-#include "Warning.h"
+#include "csm/Warning.h"
 
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>


### PR DESCRIPTION
Related to #530 

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

